### PR TITLE
Add uniform_candidate_sampler as softmax negative sampler; Fix alias sampling

### DIFF
--- a/EGES_model.py
+++ b/EGES_model.py
@@ -58,5 +58,14 @@ class EGES_Model:
             labels=self.inputs[-1],
             inputs=self.merge_emb,
             num_sampled=self.n_samped,
-            num_classes=self.num_nodes))
+            num_classes=self.num_nodes,
+            num_true=1,
+            sampled_values=tf.random.uniform_candidate_sampler(
+                true_classes=tf.cast(self.inputs[-1], tf.int64), 
+                num_true=1, 
+                num_sampled=self.n_samped, 
+                unique=True, 
+                range_max=self.num_nodes
+            )
+        ))
         return loss

--- a/alias.py
+++ b/alias.py
@@ -8,6 +8,7 @@ def create_alias_table(area_ratio):
     :return: accept,alias
     """
     l = len(area_ratio)
+    area_ratio = [prop * l for prop in area_ratio]
     accept, alias = [0] * l, [0] * l
     small, large = [], []
 


### PR DESCRIPTION
1. `tf.nn.sampled_softmax_loss` uses `tf.random.log_uniform_candidate_sampler` by default, which is not suitable in this case.
`tf.random.uniform_candidate_sampler` will be a better choice here, or we can use `tf.random.fixed_unigram_candidate_sampler` with item frequency list, to sample negative labels accroding to how often an item appears.

2. A little fix to the alias method sampling.